### PR TITLE
fix error on pattern delimiters

### DIFF
--- a/component.js
+++ b/component.js
@@ -7,7 +7,7 @@ exports.handlers = {
   beforeParse: function(e) {
     if (path.extname(e.filename) === '.vue') {
       e.componentInfo = vueDocs.parse(e.filename)
-      var script = e.source.match(/<script>(.*?)<\/script>/s)
+      var script = e.source.match(new RegExp('<script>(.*?)<\/script>', 's'))
       e.source = script[1]
     }
   },


### PR DESCRIPTION
I was receiving a `SyntaxError: Invalid regular expressing flags` error when generating docs. Defined a `RegExp` object in place to fix the issue.

![scottwatkins_Scotts-MBP____code_tailwind-react-components__zsh_](https://user-images.githubusercontent.com/128742/67970959-e762d600-fbd9-11e9-8f68-44a57a4b51ae.png)
