### PR TITLE
wrap nav links if they are too long for display

### DIFF
--- a/styles/components/sidebar.sass
+++ b/styles/components/sidebar.sass
@@ -2,6 +2,7 @@
   padding-bottom: 120px
   a
     color: $grey
+    overflow-wrap: break-word
     &:hover
       color: $red-active
   h3


### PR DESCRIPTION
If a module or class name is too long, then its text can get hidden behind the page content.  Wrapping it allows the text to show up