### PR TITLE
add search capability to the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,8 @@ So let's say you want to add `babel-polyfill` and 'bulma.css' framework to your 
 
 First of all, let me state that better-docs extends the `default` template. That is why default template parameters are also handled.
 
+You must explicitly set the `search` option of the `default` template to `true` to enable search.
+
 To customize the better-docs pass `options` to `templates['better-docs']`. section in your `jsdoc confuguration file`.
 
 Example configuration file with settings for both `default` and `better-docs` templates:
@@ -575,6 +577,7 @@ Example configuration file with settings for both `default` and `better-docs` te
     "templates": {
         "cleverLinks": false,
         "monospaceLinks": false,
+        "search": true,
         "default": {
             "staticFiles": {
               "include": [

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -1,0 +1,39 @@
+(function() {
+  const input = document.querySelector('#search')
+  const targets = [ ...document.querySelectorAll('#sidebarNav li')]
+  input.addEventListener('keyup', () => {
+    // loop over each targets and hide the not corresponding ones
+    targets.forEach(target => {
+      if (!target.innerText.includes(input.value)) {
+        target.style.display = 'none'
+
+        /**
+         * Detects an empty list
+         * Remove the list and the list's title if the list is not displayed
+         */
+        const list = [...target.parentNode.childNodes].filter( elem => elem.style.display !== 'none')
+
+        if (!list.length) {
+          target.parentNode.style.display = 'none'
+          target.parentNode.previousSibling.style.display = 'none'
+        }
+
+        /**
+         * Detects empty category
+         * Remove the entire category if no item is displayed
+         */
+        const category = [...target.parentNode.parentNode.childNodes]
+          .filter( elem => elem.tagName !== 'H2' && elem.style.display !== 'none')
+
+        if (!category.length) {
+          target.parentNode.parentNode.style.display = 'none'
+        }
+      } else {
+        target.parentNode.style.display = 'block'
+        target.parentNode.previousSibling.style.display = 'block'
+        target.parentNode.parentNode.style.display = 'block'
+        target.style.display = 'block'
+      }
+    })
+  })
+})()

--- a/styles/components/sidebar.sass
+++ b/styles/components/sidebar.sass
@@ -1,5 +1,9 @@
 .sidebar
   padding-bottom: 120px
+
+  #search
+    margin-bottom: rem(20px)
+
   a
     color: $grey
     overflow-wrap: break-word

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -6,6 +6,8 @@ if(env.conf.templates && env.conf.templates.betterDocs) {
 } else {
     betterDocs = {}
 }
+
+var search = env.conf.templates && env.conf.templates.search
 ?>
 
 <!DOCTYPE html>
@@ -69,6 +71,9 @@ if(env.conf.templates && env.conf.templates.betterDocs) {
         <div class="columns">
             <div class="column is-3" id="sidebarNav">
                 <div class="sidebar">
+                <?js if(search) { ?>
+                    <input id="search" type="text" placeholder="Search Documentations">
+                <?js } ?>
                     <nav>
                         <?js= this.nav ?>
                     </nav>
@@ -101,5 +106,8 @@ if(env.conf.templates && env.conf.templates.betterDocs) {
 
 <script src="scripts/app.min.js"></script>
 <script src="scripts/linenumber.js"> </script>
+<?js if(search) { ?>
+<script src="scripts/search.js"> </script>
+<?js } ?>
 </body>
 </html>


### PR DESCRIPTION
Fix issue #27 
User can set an option template.search to enable the search functionality.
Search is done only in the method list (names), not in the entire documentation. 