### PR TITLE
Adding missing css parameter to head

### DIFF
--- a/tmpl/head.tmpl
+++ b/tmpl/head.tmpl
@@ -19,9 +19,11 @@
   <link type="text/css" rel="stylesheet" href="https://jmblog.github.io/color-themes-for-google-code-prettify/themes/tomorrow-night.min.css">
   <link type="text/css" rel="stylesheet" href="styles/app.min.css">
   <link type="text/css" rel="stylesheet" href="styles/iframe.css">
+  <link type="text/css" rel="stylesheet" href="<?js= betterDocs.css ?>">
   <script async defer src="https://buttons.github.io/buttons.js"></script>
 
   <?js if (betterDocs.head) { ?>
     <?js= betterDocs.head ?>
   <?js } ?>
 </head>
+


### PR DESCRIPTION
Based on the documentation:
```
       "better-docs": {
            "name": "AdminBro Documentation",
            "logo": "images/logo.png",
            "title": "", // HTML title
            "css": "style.css",
            "trackingCode": "tracking-code-which-will-go-to-the-HEAD",
	    "hideGenerator": false,
            "navigation": [
                {
                    "label": "Github",
                    "href": "https://github.com/SoftwareBrothers/admin-bro"
                },
                {
                    "label": "Example Application",
                    "href": "https://admin-bro-example-app.herokuapp.com/admin"
                }
            ]
        }
```
You can pass the `css` option to customize the template, however, this is not working currently.