### PR TITLE
support parcel 2.0.0

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -80,7 +80,7 @@ module.exports = function bundle (Components, out, config) {
   fs.writeFileSync(entry, entryFile)
   console.log('Bundling components')
   const outDist = path.join(out, 'build')
-  const cmd = `${process.platform === 'win32' ? 'SET ' : ''}NODE_ENV=development parcel build ${entry} --out-dir ${outDist}`
+  const cmd = `${process.platform === 'win32' ? 'SET ' : ''}NODE_ENV=development parcel build ${entry} --dist-dir ${outDist}`
   console.log(`running: ${cmd}`)
   try {
     execSync(cmd)


### PR DESCRIPTION
npm installs parcel 2 by default now so the build fails without his.