### PR TITLE
Add support for React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "@commitlint/config-conventional": "^8.3.4"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^16.0 || ^17.0",
+    "react-dom": "^16.0 || ^17.0",
     "typescript": "^3.6.4"
   },
   "dependencies": {


### PR DESCRIPTION
Currently, `better-docs` is incompatible with React 17 projects and will throw the following error:

```
npm ERR! While resolving: candor.co@1.6.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"^17.0.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.0.0" from better-docs@2.3.2
npm ERR! node_modules/better-docs
npm ERR!   dev better-docs@"^2.3.2" from the root project 
```

This PR resolves that.