### PR TITLE
fix: removed duplicates of class properties definitions

### DIFF
--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -205,8 +205,7 @@
         <div class='vertical-section'>
             <h1>Methods</h1>
             <div class="members">
-            <?js methods.forEach(function(m, i) { ?>
-                <span><?js= m.summary ?></span>
+            <?js methods.forEach(function(m) { ?>
                 <div class="member"><?js= self.partial('method.tmpl', m) ?></div>
             <?js }); ?>
             </div>

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -194,14 +194,19 @@
     <?js
         var methods = self.find({kind: 'function', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
         if (methods && methods.length && methods.forEach) {
-            methods = methods.filter(function(m) {
-                return m.access !== 'private';
-            });
+            // Remove duplicated definition, keep overwritten by the converter
+            methods = methods.reduce((acc, method) => {
+                if(method.access === 'private') return acc
+                var index = acc.findIndex(m => m.id === method.id)
+                index < 0 ? acc.push(method) : acc[index] = method
+                return acc
+            }, [])
     ?>
         <div class='vertical-section'>
             <h1>Methods</h1>
             <div class="members">
-            <?js methods.forEach(function(m) { ?>
+            <?js methods.forEach(function(m, i) { ?>
+                <span><?js= m.summary ?></span>
                 <div class="member"><?js= self.partial('method.tmpl', m) ?></div>
             <?js }); ?>
             </div>


### PR DESCRIPTION
Issue found after #175, where functions were handled in class definitions. If some function was already well described before converter in documentation appears as duplicate and with duplicated jsdoc properties.

**Before**
![image](https://user-images.githubusercontent.com/85543813/150486223-91005a60-4c60-4dc9-88c5-4c2e4c2b7e5e.png)

**After**
![image](https://user-images.githubusercontent.com/85543813/150486082-f7cef891-240d-429f-ab0d-4a2de1323d5d.png)


After this PR methods are completed and replaced by the converter.