### PR TITLE
fix: parse class constructor

### DIFF
--- a/typescript/type-converter.js
+++ b/typescript/type-converter.js
@@ -268,12 +268,17 @@ module.exports = function typeConverter(src, filename = 'test.ts') {
           if (ts.isFunctionLike(member)) {
             memberComment = fillMethodComment(memberComment, member, src)
           }
-          if (modifiers.find((m => m === 'static'))) {
-            memberComment += '\n' + `${className}.${getName(member, src)}`
+          if (ts.isConstructorDeclaration(member)) {
+            memberComment = appendComment(memberComment, `@constructor`)
+            memberComment += `\n${className}.prototype.${className}`
           } else {
-            memberComment += '\n' + `${className}.prototype.${getName(member, src)}`
+            if (modifiers.find((m) => m === "static")) {
+              memberComment += `\n${className}.${getName(member, src)}`
+            } else {
+              memberComment += `\n${className}.prototype.${getName(member, src)}`
+            }
           }
-          comment += '\n' + memberComment
+          comment += "\n" + memberComment
         })
         return comment
       }


### PR DESCRIPTION
Handle error during parsing classes with new typescript converter.

**Before**
```
ERROR: Unable to parse /home/asobczak/softwarebrothers/adminjs/adminjs-dev/adminjs-upload/src/features/upload-file/providers/base-provider.ts: Unexpected token, expected ";" (79:29)
```
After debugging, it was a problem with parsing constructor because converter added wrong type definition and newest TypeScript treated it as a error. Please see the last line where is `string` after colon (previous version of ts ignored that)
```
/**
   * @param { string } bucket     place where files should be stored
 * @method
 */
BaseProvider.prototype.bucket: string
```

After adding condition to converter all files pars successfully.
```
Parsing /home/asobczak/softwarebrothers/adminjs/adminjs-dev/adminjs-upload/src/features/upload-file/providers/base-provider.ts ...
```