### PR TITLE
adding target blank noopener noreferrer

### DIFF
--- a/tmpl/topnav.tmpl
+++ b/tmpl/topnav.tmpl
@@ -63,6 +63,7 @@
                         <a
                             class="link user-link <?js= link.className ? link.className : '' ?>"
                             href="<?js= link.href ?>"
+                             target="_blank" rel="noopener noreferrer" 
                         >
                             <?js= link.label ?>
                         </a>


### PR DESCRIPTION
I'd suggest adding ` target="_blank" rel="noopener noreferrer" ` to the nav links, since these are generally used for external links, it might be good if they open in a new window?

```diff
 <?js if(betterDocs.navLinks && betterDocs.navLinks.length) { ?> 
                    <?js betterDocs.navLinks.forEach(function(link) { ?>
                        <a
                            class="link user-link <?js= link.className ? link.className : '' ?>"
                            href="<?js= link.href ?>"
+                             target="_blank" rel="noopener noreferrer" 
                        >
                            <?js= link.label ?>
                        </a>
                    <?js }) ?>
                <?js } ?>
```