### PR TITLE
Handle load in module definition

### DIFF
--- a/fixtures/typescript/abstract-class.ts
+++ b/fixtures/typescript/abstract-class.ts
@@ -24,3 +24,5 @@ abstract class AbstractClass {
 
   #test: string
 }
+
+export default AbstractClass

--- a/fixtures/typescript/index.doc.md
+++ b/fixtures/typescript/index.doc.md
@@ -1,0 +1,24 @@
+Module header
+============
+
+Paragraphs are separated by a blank line.
+
+2nd paragraph. *Italic*, **bold**, and `monospace`. Itemized lists
+look like:
+
+  * this one
+  * that one
+  * the other one
+
+Note that --- not considering the asterisk --- the actual text
+content starts at 4-columns in.
+
+> Block quotes are
+> written like so.
+>
+> They can span multiple paragraphs,
+> if you like.
+
+Use 3 dashes for an em-dash. Use 2 dashes for ranges (ex., "it's all
+in chapters 12--14"). Three dots ... will be converted to an ellipsis.
+Unicode is supported. ☺

--- a/fixtures/typescript/index.ts
+++ b/fixtures/typescript/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @module Classes
+ * @subcategory Abstract
+ * @section Classes
+ * @load ./index.doc.md
+ */
+
+ export { default as AbstractClass } from './abstract-class'

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,6 +1,6 @@
 {
     "tags": {
-        "allowUnknownTags": "all"
+        "allowUnknownTags": true
     },
     "source": {
         "include": [
@@ -16,6 +16,9 @@
         "load",
         "typescript"
     ],
+    "markdown": {
+      "tags": ["load"]
+    },
     "opts": {
         "encoding": "utf8",
         "destination": "docs/",

--- a/load.js
+++ b/load.js
@@ -12,7 +12,7 @@ exports.defineTags = (dictionary) => {
 
       if (doclet.classdesc) {
         doclet.classdesc = [doclet.classdesc, text].join('\n')
-      } else if (doclet.description) {
+      } else if (doclet.description || doclet.kind === 'module') {
         doclet.description = [doclet.description, text].join('\n')
       }
     },


### PR DESCRIPTION
Handle `@load` tag in TS index file

**Example**
```typescript
/**
 * @module @adminjs/mongoose
 * @subcategory Adapters
 * @section modules
 * @load ./index.doc.md
 */

export { default as Resource } from './resource'
export { default as Database } from './database'
```