### PR TITLE
Fix: Babel React component

### DIFF
--- a/component.js
+++ b/component.js
@@ -55,7 +55,7 @@ var parseReact = function (filePath, doclet) {
   var src = fs.readFileSync(filePath, 'UTF-8')
   var docGen
   try {
-    docGen = reactDocs.parse(src)
+        docGen = reactDocs.parse(src, null, null, { filename: '' })
   } catch (error) {
     if (error.message === 'No suitable component definition found.') {
       return {

--- a/component.js
+++ b/component.js
@@ -55,7 +55,7 @@ var parseReact = function (filePath, doclet) {
   var src = fs.readFileSync(filePath, 'UTF-8')
   var docGen
   try {
-        docGen = reactDocs.parse(src, null, null, { filename: '' })
+    docGen = reactDocs.parse(src, null, null, { filename: '' })
   } catch (error) {
     if (error.message === 'No suitable component definition found.') {
       return {

--- a/lib/component-renderer.js
+++ b/lib/component-renderer.js
@@ -1,5 +1,7 @@
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
@@ -9,39 +11,41 @@ var _react = _interopRequireDefault(require("react"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
 
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); Object.defineProperty(subClass, "prototype", { writable: false }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } else if (call !== void 0) { throw new TypeError("Derived constructors may only return object or undefined"); } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 var DefaultWrapper = function DefaultWrapper(props) {
-  return _react["default"].createElement("div", null, props.children);
+  return /*#__PURE__*/_react["default"].createElement("div", null, props.children);
 };
 
-var ComponentRenderer =
-/*#__PURE__*/
-function (_React$Component) {
+var ComponentRenderer = /*#__PURE__*/function (_React$Component) {
   _inherits(ComponentRenderer, _React$Component);
+
+  var _super = _createSuper(ComponentRenderer);
 
   function ComponentRenderer(props) {
     var _this;
 
     _classCallCheck(this, ComponentRenderer);
 
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(ComponentRenderer).call(this, props));
+    _this = _super.call(this, props);
     _this.Wrapper = window._CustomWrapper || DefaultWrapper;
     _this.state = {
       hasError: false,
@@ -59,7 +63,7 @@ function (_React$Component) {
     key: "render",
     value: function render() {
       var children = this.props.children;
-      return _react["default"].createElement(this.Wrapper, this.props, children);
+      return /*#__PURE__*/_react["default"].createElement(this.Wrapper, this.props, children);
     }
   }]);
 

--- a/lib/react-wrapper.js
+++ b/lib/react-wrapper.js
@@ -1,5 +1,7 @@
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
@@ -19,13 +21,15 @@ require("brace/theme/monokai");
 
 var _componentRenderer = _interopRequireDefault(require("./component-renderer"));
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj["default"] = obj; return newObj; } }
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { "default": obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj["default"] = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread2(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
@@ -33,33 +37,37 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
 
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); Object.defineProperty(subClass, "prototype", { writable: false }); if (superClass) _setPrototypeOf(subClass, superClass); }
 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
+function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } else if (call !== void 0) { throw new TypeError("Derived constructors may only return object or undefined"); } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
 window.component = null;
 
-var Wrapper =
-/*#__PURE__*/
-function (_React$Component) {
+var Wrapper = /*#__PURE__*/function (_React$Component) {
   _inherits(Wrapper, _React$Component);
+
+  var _super = _createSuper(Wrapper);
 
   function Wrapper(props) {
     var _this;
 
     _classCallCheck(this, Wrapper);
 
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(Wrapper).call(this, props));
+    _this = _super.call(this, props);
     window.component = window.component || {};
-    _this.iframeRef = _react["default"].createRef();
+    _this.iframeRef = /*#__PURE__*/_react["default"].createRef();
     _this.handleChange = _this.handleChange.bind(_assertThisInitialized(_this));
     _this.toggleEditor = _this.toggleEditor.bind(_assertThisInitialized(_this));
     var example = props.example;
@@ -85,7 +93,7 @@ function (_React$Component) {
       script.onload = script.onerror = function () {
         this.remove();
         self.setState(function (state) {
-          return _objectSpread2({}, state, {
+          return _objectSpread(_objectSpread({}, state), {}, {
             component: window.component[uniqId] || ''
           });
         });
@@ -111,7 +119,7 @@ function (_React$Component) {
     value: function handleChange(code) {
       this.executeScript(code);
       this.setState(function (state) {
-        return _objectSpread2({}, state, {
+        return _objectSpread(_objectSpread({}, state), {}, {
           example: code
         });
       });
@@ -152,7 +160,7 @@ function (_React$Component) {
     value: function toggleEditor(event) {
       event.preventDefault();
       this.setState(function (state) {
-        return _objectSpread2({}, state, {
+        return _objectSpread(_objectSpread({}, state), {}, {
           showEditor: !state.showEditor
         });
       });
@@ -166,7 +174,7 @@ function (_React$Component) {
           component = _this$state.component,
           height = _this$state.height,
           showEditor = _this$state.showEditor;
-      return _react["default"].createElement("div", null, _react["default"].createElement(_reactFrameComponent["default"], {
+      return /*#__PURE__*/_react["default"].createElement("div", null, /*#__PURE__*/_react["default"].createElement(_reactFrameComponent["default"], {
         className: "component-wrapper",
         ref: this.iframeRef,
         style: {
@@ -174,22 +182,22 @@ function (_React$Component) {
           height: height
         },
         onLoad: this.computeHeight()
-      }, _react["default"].createElement("link", {
+      }, /*#__PURE__*/_react["default"].createElement("link", {
         type: "text/css",
         rel: "stylesheet",
         href: "./build/entry.css"
-      }), _react["default"].createElement(_reactFrameComponent.FrameContextConsumer, null, function (frameContext) {
-        return _react["default"].createElement(_componentRenderer["default"], {
+      }), /*#__PURE__*/_react["default"].createElement(_reactFrameComponent.FrameContextConsumer, null, function (frameContext) {
+        return /*#__PURE__*/_react["default"].createElement(_componentRenderer["default"], {
           frameContext: frameContext
         }, component);
-      })), _react["default"].createElement("div", {
+      })), /*#__PURE__*/_react["default"].createElement("div", {
         className: "bd__button"
-      }, _react["default"].createElement("a", {
+      }, /*#__PURE__*/_react["default"].createElement("a", {
         href: "#",
         onClick: this.toggleEditor
-      }, "Modify Example Code")), showEditor ? _react["default"].createElement("div", {
+      }, "Modify Example Code")), showEditor ? /*#__PURE__*/_react["default"].createElement("div", {
         className: "field"
-      }, _react["default"].createElement(_reactAce["default"], {
+      }, /*#__PURE__*/_react["default"].createElement(_reactAce["default"], {
         style: {
           width: '100%',
           height: '200px',
@@ -213,7 +221,7 @@ function (_React$Component) {
 }(_react["default"].Component);
 
 var _default = function _default(props) {
-  return _react["default"].createElement(Wrapper, props);
+  return /*#__PURE__*/_react["default"].createElement(Wrapper, props);
 };
 
 exports["default"] = _default;


### PR DESCRIPTION
When running on a React component with the `better-docs/component` plugin enabled, this error shows up:

````
C:\<project_path>\node_modules\better-docs\component.js:68
      throw error
      ^

ConfigError: [BABEL] unknown file: Preset /* your preset */ requires a filename to be set when babel is called directly,
```
babel.transformSync(code, { filename: 'file.ts', presets: [/* your preset */] });
```
See https://babeljs.io/docs/en/options#filename for more information.
````

It appeared to be caused by the call to `reactDocs.parse()` in [component.js:58](https://github.com/SoftwareBrothers/better-docs/blob/419d4f6aef54591d54dfef034d9d705fe72dd304/component.js#L58).

By passing an empty filename argument (since it is not used anyway), the error stops being thrown and the doc builds fine.
